### PR TITLE
Fix memory leak

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "libsql",
-  "version": "0.2.0-pre.1",
+  "version": "0.2.0-pre.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "libsql",
-      "version": "0.2.0-pre.1",
+      "version": "0.2.0-pre.2",
       "cpu": [
         "x64",
         "arm64"


### PR DESCRIPTION
This PR fixes a memory leak when a database object is kept for too long.

The current implementation of a Database kept a list of all the statements that were prepared with that database in order to finalize them when the database was deallocated. The issue with this approach is that if a `Database` object it kept alive for a long time, we keep a reference to all statements ever prepared. Users can either keep a single connection in the global scope of use a single connection to send GBs of data, then they would be kept in memory.

The fix is to not keep references to the statements in the database but rather keep a strong reference to the database in each statement. When the database is closed, we take that database raw connection out of the database but don't close the db right away. Instead, we wait for each statement to be swept before dropping the connection, and closing it at the same time.

currently, you can still use a statement after the connection has been caused, and a statement will keep the underlying connection open if it's not reclaimed. However, it's less likely that someone you hold onto a statement after they have closed the connection. Nevertheless, in a follow-up, I'll try to address that by returning an error when the statement's connection was closed. I gave up right now because error handling with node is a huge PITA.
